### PR TITLE
feat: use IDB transaction's `oncomplete` to detect that all operations have finished.

### DIFF
--- a/dist/localforage-setitems.js
+++ b/dist/localforage-setitems.js
@@ -68,8 +68,16 @@
                 var dbInfo = localforageInstance._dbInfo;
                 var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
                 var store = transaction.objectStore(dbInfo.storeName);
+                var lastError;
 
-                var itemPromises = forEachItem(items, keyFn, valueFn, function (key, value) {
+                transaction.oncomplete = function() {
+                    resolve(items);
+                };
+                transaction.onabort = transaction.onerror = function(event) {
+                    reject(lastError || event.target);
+                };
+
+                forEachItem(items, keyFn, valueFn, function(key, value) {
                     // The reason we don't _save_ null is because IE 10 does
                     // not support saving the `null` type in IndexedDB. How
                     // ironic, given the bug below!
@@ -78,24 +86,12 @@
                         value = undefined;
                     }
                     var request = store.put(value, key);
-
-                    return new Promise(function (resolve, reject) {
-                        request.onsuccess = resolve;
-                        request.onerror = function () {
-                            reject(request.error);
-                        };
-                    });
+                    request.onerror = function() {
+                        lastError = request.error || request.transaction.error;
+                        reject(lastError);
+                    };
                 });
 
-                Promise.all(itemPromises).then(function () {
-                    transaction.oncomplete = function () {
-                        resolve(items);
-                    };
-                }).catch(reject);
-
-                transaction.onabort = transaction.onerror = function (event) {
-                    reject(event.target);
-                };
             }).catch(reject);
         });
         executeCallback(promise, callback);

--- a/lib/setitems-indexeddb.js
+++ b/lib/setitems-indexeddb.js
@@ -9,8 +9,16 @@ export function setItemsIndexedDB(items, keyFn, valueFn, callback) {
             var dbInfo = localforageInstance._dbInfo;
             var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
             var store = transaction.objectStore(dbInfo.storeName);
+            var lastError;
 
-            var itemPromises = forEachItem(items, keyFn, valueFn, function(key, value) {
+            transaction.oncomplete = function() {
+                resolve(items);
+            };
+            transaction.onabort = transaction.onerror = function(event) {
+                reject(lastError || event.target);
+            };
+
+            forEachItem(items, keyFn, valueFn, function(key, value) {
                 // The reason we don't _save_ null is because IE 10 does
                 // not support saving the `null` type in IndexedDB. How
                 // ironic, given the bug below!
@@ -19,24 +27,11 @@ export function setItemsIndexedDB(items, keyFn, valueFn, callback) {
                     value = undefined;
                 }
                 var request = store.put(value, key);
-
-                return new Promise(function(resolve, reject){
-                    request.onsuccess = resolve;
-                    request.onerror = function() {
-                        reject(request.error);
-                    };
-                });
-            });
-
-            Promise.all(itemPromises).then(function(){
-                transaction.oncomplete = function() {
-                    resolve(items);
+                request.onerror = function() {
+                    lastError = request.error || request.transaction.error;
+                    reject(lastError);
                 };
-            }).catch(reject);
-
-            transaction.onabort = transaction.onerror = function(event) {
-                reject(event.target);
-            };
+            });
 
         }).catch(reject);
     });


### PR DESCRIPTION
We don't have to create a promise for each `store.put()` call.
Transaction object handles success/error just fine.
