### PR TITLE
feat(IDB): use a single request.onerror function

### DIFF
--- a/dist/localforage-setitems.js
+++ b/dist/localforage-setitems.js
@@ -62,8 +62,8 @@
     function setItemsIndexedDB(items, keyFn, valueFn, callback) {
         var localforageInstance = this;
 
-        var promise = new Promise(function (resolve, reject) {
-            localforageInstance.ready().then(function () {
+        var promise = localforageInstance.ready().then(function () {
+            return new Promise(function (resolve, reject) {
                 // Inspired from @lu4 PR mozilla/localForage#318
                 var dbInfo = localforageInstance._dbInfo;
                 var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
@@ -77,6 +77,12 @@
                     reject(lastError || event.target);
                 };
 
+                function requestOnError(evt) {
+                    var request = evt.target || this;
+                    lastError = request.error || request.transaction.error;
+                    reject(lastError);
+                }
+
                 forEachItem(items, keyFn, valueFn, function(key, value) {
                     // The reason we don't _save_ null is because IE 10 does
                     // not support saving the `null` type in IndexedDB. How
@@ -86,13 +92,9 @@
                         value = undefined;
                     }
                     var request = store.put(value, key);
-                    request.onerror = function() {
-                        lastError = request.error || request.transaction.error;
-                        reject(lastError);
-                    };
+                    request.onerror = requestOnError;
                 });
-
-            }).catch(reject);
+            });
         });
         executeCallback(promise, callback);
         return promise;

--- a/lib/setitems-indexeddb.js
+++ b/lib/setitems-indexeddb.js
@@ -3,8 +3,8 @@ import { executeCallback, forEachItem } from './utils';
 export function setItemsIndexedDB(items, keyFn, valueFn, callback) {
     var localforageInstance = this;
 
-    var promise = new Promise(function(resolve, reject) {
-        localforageInstance.ready().then(function() {
+    var promise = localforageInstance.ready().then(function () {
+        return new Promise(function (resolve, reject) {
             // Inspired from @lu4 PR mozilla/localForage#318
             var dbInfo = localforageInstance._dbInfo;
             var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
@@ -18,6 +18,12 @@ export function setItemsIndexedDB(items, keyFn, valueFn, callback) {
                 reject(lastError || event.target);
             };
 
+            function requestOnError(evt) {
+                var request = evt.target || this;
+                lastError = request.error || request.transaction.error;
+                reject(lastError);
+            }
+
             forEachItem(items, keyFn, valueFn, function(key, value) {
                 // The reason we don't _save_ null is because IE 10 does
                 // not support saving the `null` type in IndexedDB. How
@@ -27,13 +33,9 @@ export function setItemsIndexedDB(items, keyFn, valueFn, callback) {
                     value = undefined;
                 }
                 var request = store.put(value, key);
-                request.onerror = function() {
-                    lastError = request.error || request.transaction.error;
-                    reject(lastError);
-                };
+                request.onerror = requestOnError;
             });
-
-        }).catch(reject);
+        });
     });
     executeCallback(promise, callback);
     return promise;


### PR DESCRIPTION
This is the same improvement as in [localForage-removeItems#2](https://github.com/localForage/localForage-removeItems/pull/2)
